### PR TITLE
Fixed problem of processes list not changing on exit

### DIFF
--- a/domovoi.py
+++ b/domovoi.py
@@ -60,7 +60,7 @@ class Domovoi:
         # Watch over the processes and respond accordingly
         while True:
             for solar_car_process in solar_car_processes:
-                if solar_car_process.check_status():
+                if solar_car_process.check_status() is not None:
                     if solar_car_process.process.returncode == 0: # Good exit, removes the process from the list
                         solar_car_processes.remove(solar_car_process)
                     elif solar_car_process.timesRestarted == settings.MAX_RESTART: # If a process restarts too many times, print this and remove it.

--- a/solar_car_process.py
+++ b/solar_car_process.py
@@ -23,5 +23,5 @@ class SolarCarProcess:
         self.timesRestarted += 1
 
     def check_status(self):
-        return self.process.poll() # Returns true if the process has terminated.
+        return self.process.poll() # Sets and returns the returncode attribute.
     


### PR DESCRIPTION
The length of solar_car_processes did not change when a process had a good exit. In other words, the process was not removed from the list and domovoi saw it as still running.